### PR TITLE
feat: convert boundary to rectangle type

### DIFF
--- a/quadtree.py
+++ b/quadtree.py
@@ -1,9 +1,8 @@
 import rectangle
 
 class QuadTree:
-    def __init__(self, width: int, height: int, node_capacity: int = 4):
-        self.width = width
-        self.height = height
+    def __init__(self, boundary: rectangle, node_capacity: int = 4):
+        self.boundary = boundary
         self.node_capacity = node_capacity
 
         self.items: rectangle = []


### PR DESCRIPTION
The quad tree's boundary is now defined as a rectangle.